### PR TITLE
kyleprods: Rework

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -129,6 +129,9 @@ TARGET_USE_CUSTOM_LUN_FILE_PATH             := /sys/class/android_usb/android0/f
 BOARD_HAS_NO_SELECT_BUTTON                  := true
 BOARD_HAS_LARGE_FILESYSTEM                  := true
 TARGET_USERIMAGES_USE_EXT4                  := true
+ifeq ($(BUILD_TWRP), true)
+TARGET_USERIMAGES_USE_F2FS                  := true
+endif
 TARGET_RECOVERY_PIXEL_FORMAT                := BGRA_8888
 BOARD_HAS_NO_MISC_PARTITION                 := true
 BOARD_RECOVERY_HANDLES_MOUNT                := true

--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -129,7 +129,6 @@ TARGET_USE_CUSTOM_LUN_FILE_PATH             := /sys/class/android_usb/android0/f
 BOARD_HAS_NO_SELECT_BUTTON                  := true
 BOARD_HAS_LARGE_FILESYSTEM                  := true
 TARGET_USERIMAGES_USE_EXT4                  := true
-TARGET_USERIMAGES_USE_F2FS                  := true
 TARGET_RECOVERY_PIXEL_FORMAT                := BGRA_8888
 BOARD_HAS_NO_MISC_PARTITION                 := true
 BOARD_RECOVERY_HANDLES_MOUNT                := true

--- a/configs/98netflix
+++ b/configs/98netflix
@@ -1,0 +1,6 @@
+#!/system/bin/sh
+
+if [ -f /data/data/com.netflix.mediaclient/shared_prefs/nfxpref.xml ]; then
+  grep -q nflx_player_type.*10 /data/data/com.netflix.mediaclient/shared_prefs/nfxpref.xml && exit 0
+  cp /data/data/com.netflix.mediaclient/shared_prefs/nfxpref.xml /data/data/com.netflix.mediaclient/shared_prefs/nfxpref.xml.orig && sed -e 's|<int name="nflx_player_type".*||g; s|</map>|<int name="nflx_player_type" value="10" />\n</map>|g' /data/data/com.netflix.mediaclient/shared_prefs/nfxpref.xml.orig > /data/data/com.netflix.mediaclient/shared_prefs/nfxpref.xml && rm /data/data/com.netflix.mediaclient/shared_prefs/nfxpref.xml.orig
+fi

--- a/device_kyleprods.mk
+++ b/device_kyleprods.mk
@@ -20,7 +20,8 @@ PRODUCT_COPY_FILES += \
 
 # Configs
 PRODUCT_COPY_FILES += \
-    device/samsung/kyleprods/configs/media_codecs.xml:system/etc/media_codecs.xml
+    device/samsung/kyleprods/configs/media_codecs.xml:system/etc/media_codecs.xml \
+    device/samsung/kyleprods/configs/98netflix:system/etc/init.d/98netflix
 
 ifeq ($(TARGET_BUILD_VARIANT),user)
     # Secure ADB
@@ -38,16 +39,7 @@ endif
 PRODUCT_PACKAGES += \
     make_ext4fs \
     e2fsck \
-    setup_fs \
-    mkfs.f2fs \
-    fsck.f2fs \
-    fibmap.f2fs
-
-# CyanogenMod has removed CMAccount but not
-# fix the SetupWizard to working without it
-# http://review.cyanogenmod.org/#/c/131177/
-PRODUCT_PACKAGES += \
-    CMAccount
+    setup_fs
 
 # USB accessory
 PRODUCT_PACKAGES += \

--- a/device_kyleprods.mk
+++ b/device_kyleprods.mk
@@ -41,6 +41,14 @@ PRODUCT_PACKAGES += \
     e2fsck \
     setup_fs
 
+# F2FS tools
+ifeq ($(BUILD_TWRP), true)
+PRODUCT_PACKAGES += \
+    mkfs.f2fs \
+    fsck.f2fs \
+    fibmap.f2fs
+endif
+
 # USB accessory
 PRODUCT_PACKAGES += \
     com.android.future.usb.accessory

--- a/rootdir/fstab.hawaii_ss_kyleprods
+++ b/rootdir/fstab.hawaii_ss_kyleprods
@@ -5,14 +5,12 @@
 # <src>                                             <mnt_point>         <type>  <mnt_flags and options>                                                         <fs_mgr_flags>
 /dev/block/platform/sdhci.1/by-name/system          /system             ext4    ro,noatime,noauto_da_alloc                                                      wait
 /dev/block/platform/sdhci.1/by-name/efs             /efs                ext4    noatime,nosuid,nodev,journal_async_commit,errors=panic                          wait,check
-/dev/block/platform/sdhci.1/by-name/CSC             /cache              f2fs    rw,nosuid,nodev,noatime,nodiratime,inline_xattr                                 wait,check,formattable
 /dev/block/platform/sdhci.1/by-name/CSC             /cache              ext4    noatime,nosuid,nodev,discard,journal_async_commit,errors=panic                  wait,check
 /dev/block/platform/sdhci.1/by-name/KERNEL          /boot               emmc    defaults                                                                        defaults
 /dev/block/platform/sdhci.1/by-name/RECOVERY        /recovery           emmc    defaults                                                                        defaults
 /dev/block/platform/sdhci.1/by-name/modem           /modem              emmc    defaults                                                                        defaults
 
 # /data partition must be located at the bottom for supporting device encryption
-/dev/block/platform/sdhci.1/by-name/userdata        /data               f2fs    rw,nosuid,nodev,noatime,nodiratime,inline_data,inline_xattr                     wait,check,formattable,encryptable=footer,length=-16384
 /dev/block/platform/sdhci.1/by-name/userdata        /data               ext4    noatime,nosuid,nodev,discard,noauto_da_alloc,journal_async_commit,errors=panic  wait,check,encryptable=footer,length=-16384
 
 # Vold-managed volumes ("block device" is actually a sysfs devpath)

--- a/rootdir/init.hawaii_ss_kyleprods.rc
+++ b/rootdir/init.hawaii_ss_kyleprods.rc
@@ -13,10 +13,8 @@ on init
     mkdir /storage/emulated 0555 root root
 
 # External storage directories
-    mkdir /mnt/media_rw/sdcard0 0700 media_rw media_rw
     mkdir /mnt/media_rw/sdcard1 0700 media_rw media_rw
 
-    mkdir /storage/sdcard0 0700 root root
     mkdir /storage/sdcard1 0700 root root
 
     export EXTERNAL_STORAGE /storage/emulated/legacy
@@ -29,9 +27,6 @@ on init
     symlink /storage/emulated/legacy /mnt/sdcard
     symlink /storage/emulated/legacy /storage/sdcard0
     symlink /mnt/shell/emulated/0 /storage/emulated/legacy
-    symlink /storage/sdcard1 /extSdCard
-    symlink /storage/sdcard1 /mnt/extSdCard
-    symlink /storage/sdcard1 /external_sd
 
 # To store widevine keybox
     symlink /data/app /factory


### PR DESCRIPTION
* Revert F2FS commits (fixes bootloop even when filesystem is EXT4)
* Cleanup internal and external storage paths
* Fix Netflix playback (needs a reboot to fix after encountering this issue (because I'm using init.d script to fix this issue)